### PR TITLE
Fix linesearch and KL divergence constraint

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,8 +37,8 @@ class TRPOAgent(object):
                 None, 2 * env.observation_space.shape[0] + env.action_space.n], name="obs")
         self.prev_obs = np.zeros((1, env.observation_space.shape[0]))
         self.prev_action = np.zeros((1, env.action_space.n))
-        self.action = action = tf.placeholder(tf.int64, shape=[None], name="action")  
-        self.advant = advant = tf.placeholder(dtype, shape=[None], name="advant")  
+        self.action = action = tf.placeholder(tf.int64, shape=[None], name="action")
+        self.advant = advant = tf.placeholder(dtype, shape=[None], name="advant")
         self.oldaction_dist = oldaction_dist = tf.placeholder(dtype, shape=[None, env.action_space.n], name="oldaction_dist")
 
         # Create neural network.
@@ -147,7 +147,7 @@ class TRPOAgent(object):
                 self.end_count += 1
                 if self.end_count > 100:
                     break
-            if self.train: 
+            if self.train:
                 self.vf.fit(paths)
                 thprev = self.gf()
 
@@ -166,7 +166,6 @@ class TRPOAgent(object):
                     self.sff(th)
                     return self.session.run(self.losses[0], feed_dict=feed)
                 theta = linesearch(loss, thprev, fullstep, neggdotstepdir / lm)
-                theta = thprev + fullstep
                 self.sff(theta)
 
                 surrafter, kloldnew, entropy = self.session.run(
@@ -209,7 +208,7 @@ env = SpaceConversionEnv(env, Box, Discrete)
 agent = TRPOAgent(env)
 agent.learn()
 env.monitor.close()
-gym.upload(training_dir, 
+gym.upload(training_dir,
            algorithm_id='trpo_ff')
 
-     
+

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ class TRPOAgent(object):
         "timesteps_per_batch": 1000,
         "max_pathlength": 10000,
         "max_kl": 0.01,
+        "cg_damping": 0.1,
         "gamma": 0.95})
 
     def __init__(self, env):
@@ -153,7 +154,7 @@ class TRPOAgent(object):
 
                 def fisher_vector_product(p):
                     feed[self.flat_tangent] = p
-                    return self.session.run(self.fvp, feed)
+                    return self.session.run(self.fvp, feed) + config.cg_damping * p
 
                 g = self.session.run(self.pg, feed_dict=feed)
                 stepdir = conjugate_gradient(fisher_vector_product, -g)


### PR DESCRIPTION
Fix #1 and #2 

Results are on:
https://gym.openai.com/evaluations/eval_yumMelmmSNWeM4RexXZX5g#reproducibility

Example logs:

```
********** Iteration 2 ************
Total number of episodes:                 1166
KL between old and new distribution:      0.00500573
Entropy:                                  2.94753
Surrogate loss:                           -0.0609315
Average sum of rewards per episode:       -0.198684210526
Baseline explained:                       -0.0523932738426
Time elapsed:                             0.20 mins
Rollout

********** Iteration 3 ************
Total number of episodes:                 1549
KL between old and new distribution:      0.00585226
Entropy:                                  2.92717
Surrogate loss:                           -0.0543403
Average sum of rewards per episode:       -0.195822454308
Baseline explained:                       -0.0704836218784
Time elapsed:                             0.29 mins
Rollout
```
